### PR TITLE
Fix ping command option parsing

### DIFF
--- a/Assets/Scripts/Terminal/Commands/PingCommand.cs
+++ b/Assets/Scripts/Terminal/Commands/PingCommand.cs
@@ -16,27 +16,28 @@ namespace Env0.Terminal
                 return result;
             }
 
-            if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+            // Optional: parse count from args (e.g., "ping -c 2 host")
+            var packetCount = 4;
+            var argIndex = 0;
+            if (args.Length > 1 && args[0] == "-c" && int.TryParse(args[1], out var c))
+            {
+                packetCount = c;
+                argIndex = 2;
+            }
+
+            if (args.Length <= argIndex || string.IsNullOrWhiteSpace(args[argIndex]))
             {
                 result.AddLine("ping: Missing hostname or IP.\n", OutputType.Error);
                 return result;
             }
 
-            var target = args[0].Trim();
+            var target = args[argIndex].Trim();
             var device = session.NetworkManager.FindDevice(target);
 
             if (device == null)
             {
                 result.AddLine($"ping: {target}: Host unreachable\n", OutputType.Error);
                 return result;
-            }
-
-            // Optional: parse count from args (e.g., "ping -c 2 host")
-            var packetCount = 4;
-            if (args.Length > 2 && args[0] == "-c" && int.TryParse(args[1], out var c))
-            {
-                packetCount = c;
-                target = args[2];
             }
 
             var results = session.NetworkManager.Ping(device, packetCount);


### PR DESCRIPTION
## Summary
- fix optional `-c` flag handling in `ping` command so host is parsed correctly

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c61798388326b1eb079f60e7e8dd